### PR TITLE
Update editor.js

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -686,7 +686,7 @@ define(['bslGlobals', 'bslMetadata', 'snippets', 'bsl_language', 'vs/editor/edit
       hideStatusBar();
     }
 
-    if (!text || !newOriginalText) {      
+    if (text || newOriginalText) {      
       
       if (language_id == 'xml') {
         language_id = 'xml';


### PR DESCRIPTION
Исправлена ошибка внесеная предыдущим коммитом в сравнение текстов. При обоих непустых текстах функция делала ничего.
Тест1 - compare("", true, true, true, true, "2")
Тест2 - compare("1", true, true, true, true, "2")
Тест3 - compare("1", true, true, true, true, "")