### PR TITLE
fix: восстановить перетаскивание скроллбаров в WebKit 1С

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -315,6 +315,99 @@ if (_self.Element && _self.Element.prototype && typeof _self.Element.prototype.r
   };
 }
 
+// Pointer Events появились только в Safari 13, а WebKit поля 1С уровня Safari 11
+// генерирует лишь mouse-события. Начиная с Monaco 0.52 весь drag-интерактив
+// (скроллбары, миникарта, sash) подписан напрямую на pointerdown/move/up, поэтому
+// без узкой трансляции ползунки видны, но не перетаскиваются (issue #386).
+//
+// Не объявляем window.PointerEvent: десктопный MouseHandler Monaco должен продолжать
+// работать с нативными mouse-событиями. setPointerCapture также не эмулируем —
+// GlobalPointerMoveMonitor ловит исключение и переносит pointermove/up-листенеры на window.
+(function () {
+  if (typeof _self.PointerEvent !== 'undefined') return;
+  if (typeof document === 'undefined' || typeof MouseEvent === 'undefined') return;
+
+  // GlobalPointerMoveMonitor сравнивает buttons каждого pointermove с состоянием на
+  // pointerdown. В WebKit без MouseEvent.buttons ведём совместимую битовую маску сами.
+  var buttonsState = 0;
+  var BUTTON_BIT = { 0: 1, 1: 4, 2: 2 };
+  if (!('buttons' in MouseEvent.prototype)) {
+    try {
+      Object.defineProperty(MouseEvent.prototype, 'buttons', {
+        configurable: true,
+        get: function () { return buttonsState; }
+      });
+    } catch (e) { /* ignore */ }
+  }
+  _self.addEventListener('blur', function () { buttonsState = 0; }, false);
+
+  function synthPointer(type, src) {
+    var event;
+    try {
+      event = new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        view: src.view || _self,
+        detail: src.detail,
+        screenX: src.screenX,
+        screenY: src.screenY,
+        clientX: src.clientX,
+        clientY: src.clientY,
+        ctrlKey: src.ctrlKey,
+        altKey: src.altKey,
+        shiftKey: src.shiftKey,
+        metaKey: src.metaKey,
+        button: src.button,
+        buttons: src.buttons,
+        relatedTarget: null
+      });
+    } catch (err) {
+      // Запасной путь для движков без конструктора MouseEvent.
+      event = document.createEvent('MouseEvents');
+      event.initMouseEvent(type, true, true, src.view || _self, src.detail,
+        src.screenX, src.screenY, src.clientX, src.clientY,
+        src.ctrlKey, src.altKey, src.shiftKey, src.metaKey, src.button, null);
+    }
+
+    // Скроллбары и миникарта получают сырое событие и читают эти поля напрямую.
+    function defineEventProperty(name, value) {
+      try { Object.defineProperty(event, name, { value: value, configurable: true }); }
+      catch (e) { /* ignore */ }
+    }
+    defineEventProperty('pointerId', 1);
+    defineEventProperty('pointerType', 'mouse');
+    defineEventProperty('isPrimary', true);
+    defineEventProperty('offsetX', src.offsetX);
+    defineEventProperty('offsetY', src.offsetY);
+    defineEventProperty('pageX', src.pageX);
+    defineEventProperty('pageY', src.pageY);
+    return event;
+  }
+
+  function translate(mouseType, pointerType, mirrorCancel) {
+    document.addEventListener(mouseType, function (src) {
+      if (mouseType === 'mousedown') buttonsState |= (BUTTON_BIT[src.button] || 0);
+      else if (mouseType === 'mouseup') buttonsState &= ~(BUTTON_BIT[src.button] || 0);
+
+      var target = src.target && src.target.dispatchEvent ? src.target : document;
+      var event = synthPointer(pointerType, src);
+      target.dispatchEvent(event);
+
+      // По спецификации отменённый pointerdown подавляет совместимый mousedown.
+      // Зеркалим это, иначе Monaco обработает один жест дважды и уведёт фокус.
+      if (mirrorCancel && event.defaultPrevented) {
+        src.preventDefault();
+        if (src.stopImmediatePropagation) src.stopImmediatePropagation();
+        else src.stopPropagation();
+      }
+    }, true);
+  }
+
+  translate('mousedown', 'pointerdown', true);
+  translate('mousemove', 'pointermove', false);
+  translate('mouseup', 'pointerup', false);
+})();
+
 // Вывод версии ES от zeegin/ecmaScriptInfo
 var ecmaScriptInfo = (function () {
     // () => { is not allowed

--- a/tools/run_tests_headless.js
+++ b/tools/run_tests_headless.js
@@ -53,6 +53,163 @@ function serve() {
   });
 }
 
+async function checkModernPointerDrag(browser, errors) {
+  const page = await browser.newPage();
+  try {
+    await page.bringToFront();
+    await page.goto('http://localhost:' + PORT + '/index.html', { waitUntil: 'load', timeout: 60000 });
+    await page.waitForFunction('!!window.editor && typeof window.monaco !== "undefined"', { timeout: 30000 });
+
+    const dimensions = await page.evaluate(async () => {
+    const editor = window.editor;
+    const longTail = new Array(300).join('ДлиннаяСтрока');
+    const lines = [];
+    for (let i = 0; i < 300; i++) lines.push('Строка' + i + ' = "' + longTail + '";');
+    editor.setValue(lines.join('\n'));
+    editor.updateOptions({ wordWrap: 'off' });
+    editor.layout();
+    editor.setPosition({ lineNumber: 1, column: editor.getModel().getLineMaxColumn(1) });
+    editor.revealPosition(editor.getPosition());
+    editor.render(true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    editor.setScrollPosition({ scrollTop: 0, scrollLeft: 0 });
+    return {
+      pointerEvent: typeof window.PointerEvent,
+      scrollWidth: editor.getScrollWidth()
+    };
+    });
+
+    async function drag(selector, deltaX, deltaY) {
+      const slider = await page.$(selector);
+      if (!slider) return false;
+      const rect = await slider.boundingBox();
+      if (!rect) return false;
+      const startX = rect.x + Math.max(1, Math.min(rect.width / 2, rect.width - 1));
+      const startY = rect.y + Math.max(1, Math.min(rect.height / 2, rect.height - 1));
+      await page.mouse.move(startX, startY);
+      await page.mouse.down({ button: 'left' });
+      await page.mouse.move(startX + deltaX, startY + deltaY, { steps: 4 });
+      await page.mouse.up({ button: 'left' });
+      return true;
+    }
+
+    const verticalFound = await drag('.monaco-scrollable-element > .scrollbar.vertical > .slider', 0, 80);
+    const scrollTop = await page.evaluate(() => window.editor.getScrollTop());
+    await page.evaluate(() => window.editor.setScrollPosition({ scrollTop: 0, scrollLeft: 0 }));
+    const horizontalFound = await drag('.monaco-scrollable-element > .scrollbar.horizontal > .slider', 80, 0);
+    const scrollLeft = await page.evaluate(() => window.editor.getScrollLeft());
+
+    if (dimensions.pointerEvent !== 'function') errors.push('modern pointer smoke: PointerEvent недоступен в Chrome');
+    if (!verticalFound || !(scrollTop > 0)) errors.push('modern pointer smoke: вертикальный slider не перетаскивается');
+    if (!horizontalFound || !(scrollLeft > 0)) errors.push('modern pointer smoke: горизонтальный slider не перетаскивается');
+    console.log('[headless] modern scrollbar drag:',
+      'vertical=' + scrollTop, '| horizontal=' + scrollLeft,
+      '| scrollWidth=' + dimensions.scrollWidth, '| PointerEvent=' + dimensions.pointerEvent);
+  } catch (e) {
+    errors.push('modern pointer smoke threw: ' + ((e && e.stack) || (e && e.message) || e));
+  } finally {
+    await page.close();
+  }
+}
+
+async function checkLegacyPointerDrag(browser, errors) {
+  const page = await browser.newPage();
+  const pageErrors = [];
+  page.on('console', (msg) => { if (msg.type() === 'error') pageErrors.push('console.error: ' + msg.text()); });
+  page.on('pageerror', (err) => pageErrors.push('pageerror: ' + ((err && err.stack) || (err && err.message) || err)));
+
+  // Эмулируем WebKit поля 1С: PointerEvent отсутствует, а жест приходит как
+  // mousedown/mousemove/mouseup. События отправляем программно, чтобы Chromium не
+  // добавлял собственную нативную pointer-последовательность.
+  await page.evaluateOnNewDocument(() => { delete window.PointerEvent; });
+
+  try {
+    await page.bringToFront();
+    await page.goto('http://localhost:' + PORT + '/index.html', { waitUntil: 'load', timeout: 60000 });
+    await page.waitForFunction('!!window.editor && typeof window.monaco !== "undefined"', { timeout: 30000 });
+
+    const result = await page.evaluate(async () => {
+      const editor = window.editor;
+      const longTail = new Array(300).join('ДлиннаяСтрока');
+      const lines = [];
+      for (let i = 0; i < 300; i++) lines.push('Строка' + i + ' = "' + longTail + '";');
+      editor.setValue(lines.join('\n'));
+      editor.updateOptions({ wordWrap: 'off' });
+      editor.layout();
+      editor.setPosition({ lineNumber: 1, column: editor.getModel().getLineMaxColumn(1) });
+      editor.revealPosition(editor.getPosition());
+      editor.render(true);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      editor.setScrollPosition({ scrollTop: 0, scrollLeft: 0 });
+
+      function drag(selector, deltaX, deltaY) {
+        const slider = document.querySelector(selector);
+        if (!slider) return { found: false };
+        const rect = slider.getBoundingClientRect();
+        const startX = rect.left + Math.max(1, Math.min(rect.width / 2, rect.width - 1));
+        const startY = rect.top + Math.max(1, Math.min(rect.height / 2, rect.height - 1));
+        const eventOptions = {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          button: 0,
+          buttons: 1,
+          clientX: startX,
+          clientY: startY
+        };
+        slider.dispatchEvent(new MouseEvent('mousedown', eventOptions));
+        slider.dispatchEvent(new MouseEvent('mousemove', Object.assign({}, eventOptions, {
+          clientX: startX + deltaX,
+          clientY: startY + deltaY
+        })));
+        slider.dispatchEvent(new MouseEvent('mouseup', Object.assign({}, eventOptions, {
+          button: 0,
+          buttons: 0,
+          clientX: startX + deltaX,
+          clientY: startY + deltaY
+        })));
+        return { found: true, width: rect.width, height: rect.height };
+      }
+
+      const vertical = drag('.monaco-scrollable-element > .scrollbar.vertical > .slider', 0, 80);
+      const scrollTop = editor.getScrollTop();
+      editor.setScrollPosition({ scrollTop: 0, scrollLeft: 0 });
+      const horizontal = drag('.monaco-scrollable-element > .scrollbar.horizontal > .slider', 80, 0);
+      const scrollLeft = editor.getScrollLeft();
+
+      return {
+        pointerEvent: typeof window.PointerEvent,
+        verticalFound: vertical.found,
+        horizontalFound: horizontal.found,
+        horizontalSliderWidth: horizontal.width,
+        scrollWidth: editor.getScrollWidth(),
+        contentWidth: editor.getLayoutInfo().contentWidth,
+        lineMaxColumn: editor.getModel().getLineMaxColumn(1),
+        wordWrap: editor.getOption(window.monaco.editor.EditorOption.wordWrap),
+        scrollTop: scrollTop,
+        scrollLeft: scrollLeft
+      };
+    });
+
+    if (result.pointerEvent !== 'undefined') errors.push('legacy pointer smoke: window.PointerEvent не отключён');
+    if (!result.verticalFound) errors.push('legacy pointer smoke: не найден вертикальный slider Monaco');
+    if (!result.horizontalFound) errors.push('legacy pointer smoke: не найден горизонтальный slider Monaco');
+    if (!(result.scrollTop > 0)) errors.push('legacy pointer smoke: вертикальный slider не изменил scrollTop');
+    if (!(result.scrollLeft > 0)) errors.push('legacy pointer smoke: горизонтальный slider не изменил scrollLeft');
+    pageErrors.forEach((e) => errors.push('legacy pointer smoke: ' + e));
+    console.log('[headless] legacy WebKit scrollbar drag:',
+      'vertical=' + result.scrollTop, '| horizontal=' + result.scrollLeft,
+      '| scrollWidth=' + result.scrollWidth, '| contentWidth=' + result.contentWidth,
+      '| lineMaxColumn=' + result.lineMaxColumn, '| wordWrap=' + result.wordWrap,
+      '| horizontalSlider=' + result.horizontalSliderWidth,
+      '| PointerEvent=' + result.pointerEvent);
+  } catch (e) {
+    errors.push('legacy pointer smoke threw: ' + ((e && e.stack) || (e && e.message) || e));
+  } finally {
+    await page.close();
+  }
+}
+
 (async () => {
   const exe = findBrowser();
   if (!exe) { console.error('Не найден Chrome/Edge. Задайте переменную окружения CHROME_PATH.'); process.exit(2); }
@@ -183,6 +340,9 @@ function serve() {
         errors.push('createDiffWidget check threw: ' + ((e && e.stack) || (e && e.message) || e));
       }
     }
+
+    await checkModernPointerDrag(browser, errors);
+    await checkLegacyPointerDrag(browser, errors);
 
     // Если появился mochaResults (этап 3) — учтём failures.
     const mocha = await page.evaluate(() => window.mochaResults || null);


### PR DESCRIPTION
## Что исправлено

- добавлена трансляция mouse-событий в Pointer Events для старого WebKit поля HTML 1С;
- восстановлено перетаскивание вертикального и горизонтального скроллбаров Monaco;
- полифилл включается только при отсутствии `window.PointerEvent`, современный браузер не затрагивается;
- добавлены headless-smoke проверки нативного и legacy-режимов.

## Проверки

- `npm run build`
- `npm run escheck`
- `npm run test:headless`
- `npm run build:test`
- `npm run test:mocha` — 173 passed
- `npm run test:query-navigation`
- `npm run test:query-model-service`

Closes #386