### PR TITLE
fix: не пересоздавать модель diff на каждое изменение текста (утечка 4 МБ на правку)

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -826,6 +826,9 @@ window.selectedText = function(text = undefined, keepSelection = false) {
       let selection = window.getSelection();
       let tempModel = monaco.editor.createModel(text);
       let tempRange = tempModel.getFullModelRange();
+
+      // модель нужна была только ради диапазона — Monaco её сам не удалит
+      tempModel.dispose();
       
       window.setText(text, window.getSelection(), false);
 
@@ -901,6 +904,9 @@ window.insertLine = function(lineNumber, text) {
   let model = window.editor.getModel();
   let text_model = monaco.editor.createModel(text);
   let text_range = text_model.getFullModelRange();
+
+  // модель нужна была только ради диапазона — Monaco её сам не удалит
+  text_model.dispose();
   let total_lines = window.getLineCount();
   let text_lines = text_range.endLineNumber - text_range.startLineNumber;
   
@@ -3525,6 +3531,9 @@ function generateSnippetEvent(e) {
         let content_model = monaco.editor.createModel(changes.text);
         let content_range = content_model.getFullModelRange();
 
+        // модель нужна была только ради диапазона — Monaco её сам не удалит
+        content_model.dispose();
+
         let target_range = new monaco.Range(
           change_range.startLineNumber,
           change_range.startColumn,
@@ -5058,10 +5067,30 @@ function calculateDiff() {
         });
       }
 
-      window.diffEditor.setModel({
-        original: monaco.editor.createModel(window.editor.originalText),
-        modified: window.editor.getModel()
-      });
+      // Сюда приходим на каждое изменение текста. Пересоздавать original-модель каждый раз
+      // нельзя: это полная копия оригинала (на модуле в полмегабайта — по копии на пачку правок),
+      // а Monaco модели сам не диспозит. Если оригинал и модель редактора не менялись, diff
+      // пересчитается сам по изменению modified-модели — трогать setModel не нужно.
+      let previous = window.diffEditor.getModel();
+
+      let reusable = previous
+        && previous.original && !previous.original.isDisposed()
+        && previous.modified === window.editor.getModel()
+        && window.diffEditor.originalTextRef === window.editor.originalText;
+
+      if (!reusable) {
+
+        window.diffEditor.setModel({
+          original: monaco.editor.createModel(window.editor.originalText),
+          modified: window.editor.getModel()
+        });
+
+        window.diffEditor.originalTextRef = window.editor.originalText;
+
+        if (previous && previous.original && !previous.original.isDisposed())
+          previous.original.dispose();
+
+      }
 
     }, 50);
 


### PR DESCRIPTION
`calculateDiff()` висит на `onDidChangeModelContent` (дебаунс 50 мс), то есть срабатывает
практически на каждое изменение текста, и каждый раз создавал новую `TextModel` с полной копией
оригинала:

```js
window.diffEditor.setModel({
  original: monaco.editor.createModel(window.editor.originalText),
  modified: window.editor.getModel()
});
```

Прежняя модель не удалялась — Monaco модели сам не диспозит. Условие срабатывания: задан
оригинальный текст (`setOriginalText`) и включены diff-декорации, то есть штатный режим
с отслеживанием изменений.

## Сколько это стоит в поле 1С

A/B двумя сборками, отличие ровно в этом изменении. Модуль 312 тыс. символов, сценарий —
N циклов «символ → точка → `Esc` → два `Backspace`» с паузами (быстрый автоповтор не годится:
дебаунс схлопывает его в считанные вызовы).

| | без исправления | с исправлением |
| --- | --- | --- |
| правок текста | 31 | 81 |
| моделей Monaco: до → после | 3 → **34** | 2 → **2** |
| Working Set: до → после, МБ | 666.4 → 793.0 | 722.7 → 668.7 |
| Private bytes: до → после, МБ | 611.6 → 753.1 | 667.3 → 604.3 |
| Δ памяти | **+126.6 МБ** | **−54.0 МБ** |

Утёкших моделей ровно столько же, сколько правок. Вес копии равен весу открытого модуля:
312 тыс. символов ≈ 4.5 МБ на модель с токенизацией — **4.1 МБ на каждую правку текста**.
Закрытие формы их не возвращает: в поле 1С редактор живёт внутри процесса `1cv8c.exe`,
отдельного процесса под webview нет, и память отдаётся только со смертью клиента.

Повторная проверка на большей выборке: 94 правки — моделей по-прежнему 2, работа стоила
0.86 МБ на правку против 4.1 МБ до исправления.

В Chrome утечка почти не видна (модели шарят строки, GC работает): на 120 срабатываний прирост
heap 3.5 МБ. Ловится только полевым замером.

## Что изменено

- `calculateDiff()` не пересоздаёт `original`-модель, если оригинал и модель редактора не менялись:
  diff пересчитается сам по изменению `modified`-модели. При реальной смене оригинала прежняя
  модель диспозится.
- Сняты три временные модели, создававшиеся только ради `getFullModelRange()`:
  `selectedText()`, `insertLine()`, `generateSnippetEvent()`.

Диф — один файл, 33 строки.

## Проверено

- `npm test`
- `npm run build:test` + `npm run test:mocha` — 201/201
- `npm run escheck` — es2018, Blob-воркеры совместимы
- браузерный пробник: 300 + 50 + 100 + 200 правок, 5 × `setText`, 3 × вкл/выкл сравнения,
  50 × подсказок — моделей остаётся 2 (до исправления росло до 6 и дальше)
- полевой A/B выше

🤖 Generated with [Claude Code](https://claude.com/claude-code)
